### PR TITLE
Ensures correct links are shown on pub.dev and GitHub

### DIFF
--- a/shrink_core/CHANGELOG.md
+++ b/shrink_core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `shrink` package will be documented in this file.
 
+## 1.5.8
+
+- Updated `repository`, `homepage`, and `issue_tracker` fields in pubspec.yaml
+- Ensures correct links are shown on pub.dev and GitHub
+
 ## 1.5.7
 
 - Refactored the internal compression method selection logic for better maintainability

--- a/shrink_core/pubspec.yaml
+++ b/shrink_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: shrink
 description: "Effortless, one-line compression. Just call shrink and save 5x-40x in size. Optimized for Firebase, JSON, structured data, or anything you want to shrink!"
 version: 1.5.7
 homepage: https://github.com/jozzzzep/shrink
-repository: https://github.com/jozzzzep/shrink
+repository: https://github.com/jozzzzep/shrink/tree/main/shrink_core
 issue_tracker: https://github.com/jozzzzep/shrink/issues
 topics:
   - compress

--- a/shrink_flutter/CHANGELOG.md
+++ b/shrink_flutter/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `shrink_flutter` package will be documented in this file.
 
+## 0.0.3
+
+- Updated `repository`, `homepage`, and `issue_tracker` fields in pubspec.yaml
+- Ensures correct links are shown on pub.dev and GitHub
+
 ## 0.0.2
 
 - **FEAT**(shrink_flutter): add ShrinkAsync and RestoreAsync for isolate-based compression/decompression.

--- a/shrink_flutter/pubspec.yaml
+++ b/shrink_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: shrink_flutter
 description: Flutter utilities for the `shrink` package
 version: 0.0.2
 homepage: https://github.com/jozzzzep/shrink
-repository: https://github.com/jozzzzep/shrink
+repository: https://github.com/jozzzzep/shrink/tree/main/shrink_flutter
 issue_tracker: https://github.com/jozzzzep/shrink/issues
 topics:
   - compress


### PR DESCRIPTION
- Updated `repository`, `homepage`, and `issue_tracker` fields in pubspec.yaml for:
  - shrink_core (shrink)
  - shrink_flutter
- Ensures correct links are shown on pub.dev and GitHub
